### PR TITLE
Fixed AP on vs(type) Madness ZG weps

### DIFF
--- a/js/data/gear_turtle.js
+++ b/js/data/gear_turtle.js
@@ -10602,7 +10602,8 @@ var gear = {
       "type": "Axe"
     },
     {
-      "name": "Gri'lek's Carver",
+      "name": "Gri'lek's Carver (vs Dragonkin)",
+      "ap": 117
       "mindmg": 182,
       "maxdmg": 274,
       "speed": 3.9,
@@ -11047,7 +11048,8 @@ var gear = {
       "type": "Polearm"
     },
     {
-      "name": "Pitchfork of Madness",
+      "name": "Pitchfork of Madness (vs Demons)",
+      "ap": 117
       "mindmg": 163,
       "maxdmg": 246,
       "speed": 3.5,
@@ -11388,6 +11390,18 @@ var gear = {
         "dmg": 90
       }
     }
+    {
+      "id": 19961,
+      "name": "Gri'lek's Grinder (vs Dragonkin)",
+      "ap": 48
+      "mindmg": 75,
+      "maxdmg": 140,
+      "speed": 2.4,
+      "type": "Mace",
+      "source": "ZG",
+      "phase": 4,
+      }
+    },
   ],
   "custom": [
     {


### PR DESCRIPTION
Gri'lek's Carver and Pitchfork of Madness now have (vs Dragonkin) and (vs Demons) in their names, with the appropriate AP. Gri'lek's Grinder added with the same format.

This follows the format from items such as Deathrune Leggings and the AD trinket.