### PR TITLE
[ fix ] fresh builds may be stopped by a missing lib folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ nvm use 11.15.0
 npm run dev
 ```
 
-After making code changes and testing that they work, make sure to rebuild the dist/ files:
+After making code changes and testing that they work, make sure to rebuild the dist/ files and commit them as well:
 ```bash
 npm run dist
 git add .

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,10 +5,13 @@ var minify = require('gulp-minify');
 var rename = require('gulp-rename');
 var stripCode = require('gulp-strip-code');
 var browser = require('browser-sync').create();
+var fs = require('fs');
+
+const libFiles = ["js/**/*.js", ...(fs.existsSync('lib') ? ["lib/*.mjs"] : [])];
 
 gulp.task("js", function () {
     return gulp
-        .src(["js/**/*.js", "lib/*.mjs"])
+        .src(libFiles)
         .pipe(rename(function (path) {
             path.extname = ".min.js";
         }))
@@ -17,7 +20,7 @@ gulp.task("js", function () {
 
 gulp.task("js-build", function () {
     return gulp
-        .src(["js/**/*.js", "lib/*.mjs"])
+        .src(libFiles)
         // .pipe(stripCode({
         //     start_comment: "start-log",
         //     end_comment: "end-log"


### PR DESCRIPTION
Missing lib folder was causing fresh pull to not build, this code fix to allow that to proceed.
Alternative options, add a dummy lib folder to the repo, or remove lib/ from the gulpfile entirely but having just started using this I'm not sure if lib/ ends up used eventually by some builds/builders.